### PR TITLE
add additional babel plugins to cover more use-cases, fixes #11

### DIFF
--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -80,7 +80,7 @@ export const parseDocument = (editor: TextEditor) => {
   try {
     const file = parse(editor.document.getText(), {
       sourceType: "module",
-      plugins: ["jsx", "typescript"]
+      plugins: ["jsx", "typescript", ["decorators", { decoratorsBeforeExport: true }], "classProperties"]
     });
 
     const { selectedElement, insertPosition } = findTagAndInsertPosition(


### PR DESCRIPTION
Hey there, figured out why I couldn't get it working for my component, it's because it was throwing a parsing error due to some of experimental plugins I'm using.  

This PR adds two plugins, (`decorators` and `classProperties`) to the babel parser that get it working for me, but I understand if this falls outside the scope of your intended use case. 